### PR TITLE
New observer controls

### DIFF
--- a/source/dagonBackend.d
+++ b/source/dagonBackend.d
@@ -1385,7 +1385,7 @@ final class SacScene: Scene{
 		bool pressed(int[] keyCodes){ return keyCodes.any!(key=>eventManager.keyPressed[key]);}
 		updateCameraTarget();
 		if(camera.target==0){
-			// Normal (camera-dependant) movement
+			// Normal (camera-dependent) movement
 			if(pressed(options.hotkeys.moveForward)) dir += -forward;
 			if(pressed(options.hotkeys.moveBackward)) dir += forward;
 			if(pressed(options.hotkeys.turnLeft)) dir += -right;

--- a/source/dagonBackend.d
+++ b/source/dagonBackend.d
@@ -986,7 +986,11 @@ final class SacScene: Scene{
 			Lswitch: final switch(command) with(Bindable){
 				case unknown: break;
 				// control keys
-				case moveForward,moveBackward,turnLeft,turnRight,cameraZoomIn,cameraZoomOut: enforce(0,"bad hotkeys"); break;
+				case moveForward,moveBackward,turnLeft,turnRight,cameraZoomIn,cameraZoomOut:
+				case moveUp, moveDown:
+				case cameraUp, cameraDown, cameraLeft, cameraRight, cameraForward, cameraBackward:
+					enforce(0,"bad hotkeys");
+					break;
 				// orders
 				case attack:
 					if(mouse.status==MouseStatus.standard&&!mouse.dragging){
@@ -1109,12 +1113,6 @@ final class SacScene: Scene{
 				// SacEngine extensions
 				case surrender:
 					controller.addCommand(Command!DagonBackend(renderSide));
-					break;
-				case moveUp, moveDown:
-					enforce(0,"bad hotkeys");
-					break;
-				case cameraUp, cameraDown, cameraLeft, cameraRight, cameraForward, cameraBackward:
-					enforce(0,"bad hotkeys");
 					break;
 			}
 		}

--- a/source/dagonBackend.d
+++ b/source/dagonBackend.d
@@ -1113,6 +1113,9 @@ final class SacScene: Scene{
 				case moveUp, moveDown:
 					enforce(0,"bad hotkeys");
 					break;
+				case cameraUp, cameraDown, cameraLeft, cameraRight, cameraForward, cameraBackward:
+					enforce(0,"bad hotkeys");
+					break;
 			}
 		}
 		foreach(ref hotkey;options.hotkeys[modifiers]){
@@ -1374,6 +1377,9 @@ final class SacScene: Scene{
 		Vector3f forward = fpview.camera.worldTrans.forward;
 		Vector3f right = fpview.camera.worldTrans.right;
 		Vector3f upVector = fpview.camera.worldTrans.up;
+		Vector3f cameraForward = fpview.camera.observerTrans.forward;
+		Vector3f cameraRight = fpview.camera.observerTrans.right;
+		Vector3f cameraUpVector = fpview.camera.observerTrans.up;
 		Vector3f dir = Vector3f(0, 0, 0);
 		//if(eventManager.keyPressed[KEY_X]) dir += Vector3f(1,0,0);
 		//if(eventManager.keyPressed[KEY_Y]) dir += Vector3f(0,1,0);
@@ -1381,12 +1387,21 @@ final class SacScene: Scene{
 		bool pressed(int[] keyCodes){ return keyCodes.any!(key=>eventManager.keyPressed[key]);}
 		updateCameraTarget();
 		if(camera.target==0){
+			// Normal (camera-dependant) movement
 			if(pressed(options.hotkeys.moveForward)) dir += -forward;
 			if(pressed(options.hotkeys.moveBackward)) dir += forward;
 			if(pressed(options.hotkeys.turnLeft)) dir += -right;
 			if(pressed(options.hotkeys.turnRight)) dir += right;
 			if(pressed(options.hotkeys.moveUp)) dir += -upVector;
 			if(pressed(options.hotkeys.moveDown)) dir += upVector;
+			// Absolute (camera-agnostic) movement
+			if(pressed(options.hotkeys.cameraForward)) dir += -cameraForward;
+			if(pressed(options.hotkeys.cameraBackward)) dir += cameraForward;
+			if(pressed(options.hotkeys.cameraLeft)) dir += -cameraRight;
+			if(pressed(options.hotkeys.cameraRight)) dir += cameraRight;
+			if(pressed(options.hotkeys.cameraUp)) dir += -cameraUpVector;
+			if(pressed(options.hotkeys.cameraDown)) dir += cameraUpVector;
+
 			if(eventManager.keyPressed[KEY_I]) speed = 10.0f;
 			if(eventManager.keyPressed[KEY_O]) speed = 100.0f;
 			if(eventManager.keyPressed[KEY_P]) speed = 1000.0f;

--- a/source/dagonBackend.d
+++ b/source/dagonBackend.d
@@ -1110,6 +1110,9 @@ final class SacScene: Scene{
 				case surrender:
 					controller.addCommand(Command!DagonBackend(renderSide));
 					break;
+				case moveUp, moveDown:
+					enforce(0,"bad hotkeys");
+					break;
 			}
 		}
 		foreach(ref hotkey;options.hotkeys[modifiers]){
@@ -1370,6 +1373,7 @@ final class SacScene: Scene{
 	void observerControl(Duration dt){
 		Vector3f forward = fpview.camera.worldTrans.forward;
 		Vector3f right = fpview.camera.worldTrans.right;
+		Vector3f upVector = fpview.camera.worldTrans.up;
 		Vector3f dir = Vector3f(0, 0, 0);
 		//if(eventManager.keyPressed[KEY_X]) dir += Vector3f(1,0,0);
 		//if(eventManager.keyPressed[KEY_Y]) dir += Vector3f(0,1,0);
@@ -1381,6 +1385,8 @@ final class SacScene: Scene{
 			if(pressed(options.hotkeys.moveBackward)) dir += forward;
 			if(pressed(options.hotkeys.turnLeft)) dir += -right;
 			if(pressed(options.hotkeys.turnRight)) dir += right;
+			if(pressed(options.hotkeys.moveUp)) dir += -upVector;
+			if(pressed(options.hotkeys.moveDown)) dir += upVector;
 			if(eventManager.keyPressed[KEY_I]) speed = 10.0f;
 			if(eventManager.keyPressed[KEY_O]) speed = 100.0f;
 			if(eventManager.keyPressed[KEY_P]) speed = 1000.0f;

--- a/source/dagonBackend.d
+++ b/source/dagonBackend.d
@@ -1374,10 +1374,10 @@ final class SacScene: Scene{
 	void observerControl(Duration dt){
 		Vector3f forward = fpview.camera.worldTrans.forward;
 		Vector3f right = fpview.camera.worldTrans.right;
-		Vector3f upVector = fpview.camera.worldTrans.up;
+		Vector3f down = fpview.camera.worldTrans.up;
 		Vector3f cameraForward = fpview.camera.observerTrans.forward;
 		Vector3f cameraRight = fpview.camera.observerTrans.right;
-		Vector3f cameraUpVector = fpview.camera.observerTrans.up;
+		Vector3f cameraDown = fpview.camera.observerTrans.up;
 		Vector3f dir = Vector3f(0, 0, 0);
 		//if(eventManager.keyPressed[KEY_X]) dir += Vector3f(1,0,0);
 		//if(eventManager.keyPressed[KEY_Y]) dir += Vector3f(0,1,0);
@@ -1390,15 +1390,15 @@ final class SacScene: Scene{
 			if(pressed(options.hotkeys.moveBackward)) dir += forward;
 			if(pressed(options.hotkeys.turnLeft)) dir += -right;
 			if(pressed(options.hotkeys.turnRight)) dir += right;
-			if(pressed(options.hotkeys.moveUp)) dir += -upVector;
-			if(pressed(options.hotkeys.moveDown)) dir += upVector;
+			if(pressed(options.hotkeys.moveUp)) dir += -down;
+			if(pressed(options.hotkeys.moveDown)) dir += down;
 			// Absolute (camera-agnostic) movement
 			if(pressed(options.hotkeys.cameraForward)) dir += -cameraForward;
 			if(pressed(options.hotkeys.cameraBackward)) dir += cameraForward;
 			if(pressed(options.hotkeys.cameraLeft)) dir += -cameraRight;
 			if(pressed(options.hotkeys.cameraRight)) dir += cameraRight;
-			if(pressed(options.hotkeys.cameraUp)) dir += -cameraUpVector;
-			if(pressed(options.hotkeys.cameraDown)) dir += cameraUpVector;
+			if(pressed(options.hotkeys.cameraUp)) dir += -cameraDown;
+			if(pressed(options.hotkeys.cameraDown)) dir += cameraDown;
 
 			if(eventManager.keyPressed[KEY_I]) speed = 10.0f;
 			if(eventManager.keyPressed[KEY_O]) speed = 100.0f;

--- a/source/hotkeys_.d
+++ b/source/hotkeys_.d
@@ -213,7 +213,7 @@ struct ModHotkey{
 
 struct Hotkeys{
 	bool capsIsCtrl=true;
-	int[] moveForward,moveBackward,turnLeft,turnRight;
+	int[] moveForward,moveBackward,turnLeft,turnRight, moveUp, moveDown;
 	int[] cameraZoomIn,cameraZoomOut;
 	Hotkey[][Modifiers.max+1] hotkeys;
 	alias hotkeys this;
@@ -231,9 +231,6 @@ Hotkeys defaultHotkeys(){
 	result.turnRight=[KEY_F,KEY_RIGHT];
 	result.cameraZoomIn=[KEY_KP_PLUS,KEY_EQUALS];
 	result.cameraZoomOut=[KEY_KP_MINUS,KEY_MINUS];
-	// new controls
-	result[Modifiers.ctrl]~=Hotkey(KEY_Q,Bindable.moveUp);
-	result[Modifiers.ctrl]~=Hotkey(KEY_E,Bindable.moveDown);
 	// orders
 	result[Modifiers.ctrl]~=Hotkey(KEY_R,Bindable.attack);
 	result[Modifiers.ctrl]~=Hotkey(KEY_A,Bindable.guard);
@@ -375,6 +372,8 @@ Hotkeys parseHotkeys(string hotkeys){
 				case turnRight: result.turnRight~=modKeycode.keycode; break;
 				case cameraZoomIn: result.cameraZoomIn~=modKeycode.keycode; break;
 				case cameraZoomOut: result.cameraZoomOut~=modKeycode.keycode; break;
+				case moveUp: result.moveUp~=modKeycode.keycode; break;
+				case moveDown: result.moveDown~=modKeycode.keycode; break;
 				default: result.add(ModHotkey(modKeycode.mod,Hotkey(modKeycode.keycode,bindable)));
 			}
 		}

--- a/source/hotkeys_.d
+++ b/source/hotkeys_.d
@@ -21,10 +21,16 @@ enum Bindable:char[4]{
 	moveBackward="kabM",
 	turnLeft="tflM",
 	turnRight="tgrM",
-	cameraZoomIn="imzM",
-	cameraZoomOut="omzM",
 	moveUp="puvM",		//FIXME
 	moveDown="nwdM",	//FIXME
+	cameraZoomIn="imzM",
+	cameraZoomOut="omzM",
+	cameraUp="upcM",
+	cameraDown="dncM",
+	cameraForward="wfcM",
+	cameraBackward="wbcM",
+	cameraLeft="tlcM",
+	cameraRight="trcM",
 	// orders
 	attack="ttat",
 	guard="augt",
@@ -135,10 +141,16 @@ string defaultName(Bindable bindable){
 		case moveBackward: return "Move Backward";
 		case turnLeft: return "Turn Left";
 		case turnRight: return "Turn Right";
-		case cameraZoomIn: return "Camera zoom in";
-		case cameraZoomOut: return "Camera zoom out";
 		case moveUp: return "Move Up";
 		case moveDown: return "Move Down";
+		case cameraForward: return "Camera Move Forward";
+		case cameraBackward: return "Camera Move Backward";
+		case cameraUp: return "Camera Move Up";
+		case cameraDown: return "Camera Move Down";
+		case cameraLeft: return "Camera Move Left";
+		case cameraRight: return "Camera Move Right";
+		case cameraZoomIn: return "Camera zoom in";
+		case cameraZoomOut: return "Camera zoom out";
 		// orders
 		case attack: return "Attack";
 		case guard: return "Guard";
@@ -214,7 +226,7 @@ struct ModHotkey{
 struct Hotkeys{
 	bool capsIsCtrl=true;
 	int[] moveForward,moveBackward,turnLeft,turnRight, moveUp, moveDown;
-	int[] cameraZoomIn,cameraZoomOut;
+	int[] cameraZoomIn,cameraZoomOut, cameraUp, cameraDown, cameraLeft, cameraRight, cameraForward, cameraBackward;
 	Hotkey[][Modifiers.max+1] hotkeys;
 	alias hotkeys this;
 	void add(ModHotkey modHotkey){
@@ -370,10 +382,18 @@ Hotkeys parseHotkeys(string hotkeys){
 				case moveBackward: result.moveBackward~=modKeycode.keycode; break;
 				case turnLeft: result.turnLeft~=modKeycode.keycode; break;
 				case turnRight: result.turnRight~=modKeycode.keycode; break;
-				case cameraZoomIn: result.cameraZoomIn~=modKeycode.keycode; break;
-				case cameraZoomOut: result.cameraZoomOut~=modKeycode.keycode; break;
 				case moveUp: result.moveUp~=modKeycode.keycode; break;
 				case moveDown: result.moveDown~=modKeycode.keycode; break;
+
+				case cameraZoomIn: result.cameraZoomIn~=modKeycode.keycode; break;
+				case cameraZoomOut: result.cameraZoomOut~=modKeycode.keycode; break;
+				case cameraUp: result.cameraUp~=modKeycode.keycode; break;
+				case cameraDown: result.cameraDown~=modKeycode.keycode; break;
+				case cameraLeft: result.cameraLeft~=modKeycode.keycode; break;
+				case cameraRight: result.cameraRight~=modKeycode.keycode; break;
+				case cameraForward: result.cameraForward~=modKeycode.keycode; break;
+				case cameraBackward: result.cameraBackward~=modKeycode.keycode; break;
+
 				default: result.add(ModHotkey(modKeycode.mod,Hotkey(modKeycode.keycode,bindable)));
 			}
 		}

--- a/source/hotkeys_.d
+++ b/source/hotkeys_.d
@@ -21,16 +21,8 @@ enum Bindable:char[4]{
 	moveBackward="kabM",
 	turnLeft="tflM",
 	turnRight="tgrM",
-	moveUp="puvM",		//FIXME
-	moveDown="nwdM",	//FIXME
 	cameraZoomIn="imzM",
 	cameraZoomOut="omzM",
-	cameraUp="upcM",
-	cameraDown="dncM",
-	cameraForward="wfcM",
-	cameraBackward="wbcM",
-	cameraLeft="tlcM",
-	cameraRight="trcM",
 	// orders
 	attack="ttat",
 	guard="augt",
@@ -131,6 +123,14 @@ enum Bindable:char[4]{
 	// TODO
 	// SacEngine extensions
 	surrender="rrus",
+	moveUp="puvM",
+	moveDown="nwdM",
+	cameraUp="upcM",
+	cameraDown="dncM",
+	cameraForward="wfcM",
+	cameraBackward="wbcM",
+	cameraLeft="tlcM",
+	cameraRight="trcM",
 }
 
 string defaultName(Bindable bindable){
@@ -141,14 +141,6 @@ string defaultName(Bindable bindable){
 		case moveBackward: return "Move Backward";
 		case turnLeft: return "Turn Left";
 		case turnRight: return "Turn Right";
-		case moveUp: return "Move Up";
-		case moveDown: return "Move Down";
-		case cameraForward: return "Camera Move Forward";
-		case cameraBackward: return "Camera Move Backward";
-		case cameraUp: return "Camera Move Up";
-		case cameraDown: return "Camera Move Down";
-		case cameraLeft: return "Camera Move Left";
-		case cameraRight: return "Camera Move Right";
 		case cameraZoomIn: return "Camera zoom in";
 		case cameraZoomOut: return "Camera zoom out";
 		// orders
@@ -200,6 +192,15 @@ string defaultName(Bindable bindable){
 		case castShrine: return "Cast Shrine";
 		// SacEngine extensions
 		case surrender: return "Surrender";
+		case moveUp: return "Move Up";
+		case moveDown: return "Move Down";
+		case cameraForward: return "Camera Move Forward";
+		case cameraBackward: return "Camera Move Backward";
+		case cameraUp: return "Camera Move Up";
+		case cameraDown: return "Camera Move Down";
+		case cameraLeft: return "Camera Move Left";
+		case cameraRight: return "Camera Move Right";
+
 	}
 }
 
@@ -225,8 +226,10 @@ struct ModHotkey{
 
 struct Hotkeys{
 	bool capsIsCtrl=true;
-	int[] moveForward,moveBackward,turnLeft,turnRight, moveUp, moveDown;
-	int[] cameraZoomIn,cameraZoomOut, cameraUp, cameraDown, cameraLeft, cameraRight, cameraForward, cameraBackward;
+	int[] moveForward,moveBackward,turnLeft,turnRight;
+	int[] moveUp,moveDown;
+	int[] cameraZoomIn,cameraZoomOut;
+	int[] cameraUp,cameraDown,cameraLeft,cameraRight,cameraForward,cameraBackward;
 	Hotkey[][Modifiers.max+1] hotkeys;
 	alias hotkeys this;
 	void add(ModHotkey modHotkey){

--- a/source/hotkeys_.d
+++ b/source/hotkeys_.d
@@ -228,8 +228,8 @@ struct Hotkeys{
 	bool capsIsCtrl=true;
 	int[] moveForward,moveBackward,turnLeft,turnRight;
 	int[] moveUp,moveDown;
-	int[] cameraZoomIn,cameraZoomOut;
 	int[] cameraUp,cameraDown,cameraLeft,cameraRight,cameraForward,cameraBackward;
+	int[] cameraZoomIn,cameraZoomOut;
 	Hotkey[][Modifiers.max+1] hotkeys;
 	alias hotkeys this;
 	void add(ModHotkey modHotkey){
@@ -388,14 +388,14 @@ Hotkeys parseHotkeys(string hotkeys){
 				case moveUp: result.moveUp~=modKeycode.keycode; break;
 				case moveDown: result.moveDown~=modKeycode.keycode; break;
 
-				case cameraZoomIn: result.cameraZoomIn~=modKeycode.keycode; break;
-				case cameraZoomOut: result.cameraZoomOut~=modKeycode.keycode; break;
 				case cameraUp: result.cameraUp~=modKeycode.keycode; break;
 				case cameraDown: result.cameraDown~=modKeycode.keycode; break;
 				case cameraLeft: result.cameraLeft~=modKeycode.keycode; break;
 				case cameraRight: result.cameraRight~=modKeycode.keycode; break;
 				case cameraForward: result.cameraForward~=modKeycode.keycode; break;
 				case cameraBackward: result.cameraBackward~=modKeycode.keycode; break;
+				case cameraZoomIn: result.cameraZoomIn~=modKeycode.keycode; break;
+				case cameraZoomOut: result.cameraZoomOut~=modKeycode.keycode; break;
 
 				default: result.add(ModHotkey(modKeycode.mod,Hotkey(modKeycode.keycode,bindable)));
 			}

--- a/source/hotkeys_.d
+++ b/source/hotkeys_.d
@@ -23,6 +23,8 @@ enum Bindable:char[4]{
 	turnRight="tgrM",
 	cameraZoomIn="imzM",
 	cameraZoomOut="omzM",
+	moveUp="puvM",		//FIXME
+	moveDown="nwdM",	//FIXME
 	// orders
 	attack="ttat",
 	guard="augt",
@@ -135,6 +137,8 @@ string defaultName(Bindable bindable){
 		case turnRight: return "Turn Right";
 		case cameraZoomIn: return "Camera zoom in";
 		case cameraZoomOut: return "Camera zoom out";
+		case moveUp: return "Move Up";
+		case moveDown: return "Move Down";
 		// orders
 		case attack: return "Attack";
 		case guard: return "Guard";
@@ -227,6 +231,9 @@ Hotkeys defaultHotkeys(){
 	result.turnRight=[KEY_F,KEY_RIGHT];
 	result.cameraZoomIn=[KEY_KP_PLUS,KEY_EQUALS];
 	result.cameraZoomOut=[KEY_KP_MINUS,KEY_MINUS];
+	// new controls
+	result[Modifiers.ctrl]~=Hotkey(KEY_Q,Bindable.moveUp);
+	result[Modifiers.ctrl]~=Hotkey(KEY_E,Bindable.moveDown);
 	// orders
 	result[Modifiers.ctrl]~=Hotkey(KEY_R,Bindable.attack);
 	result[Modifiers.ctrl]~=Hotkey(KEY_A,Bindable.guard);


### PR DESCRIPTION
For the time being it adds the camera-dependant "move up" and "move down" commands.

While I had them setup in my hotkeys as ctrl+q and ctrl+e, they work fine without ctrl, so something is broken in there.

That being said, the upcoming "camera-independant" movements will require changes to Dagon as well.

Relevant new entries from the hotkeys.txt
```
Move Forward:    w
Move Backward:   s
Turn Left:       a
Turn Right:      d
Move Up:	Ctrl-q
Move Down:	Ctrl-e
Camera Move Forward: t
Camera Move Backward: g
Camera Move Up: r
Camera Move Down: y
Camera Move Left: f
Camera Move Right: h
Camera zoom in:  Keypad-+ or =
Camera zoom out: Keypad-- or -
```